### PR TITLE
Wrap Deno.readTextFile to include path in NotFound errors

### DIFF
--- a/_util.ts
+++ b/_util.ts
@@ -67,3 +67,21 @@ export function size(size: number) {
   const unit = units[index];
   return `${Math.ceil(number)}${unit}`;
 }
+
+export async function readTextFile(
+  ...args: Parameters<typeof Deno.readTextFile>
+) {
+  const [path] = args;
+
+  try {
+    return await Deno.readTextFile(...args);
+  } catch (error) {
+    const message: string = error.message;
+
+    if (error.name === "NotFound" && !message.includes(`${path}`)) {
+      error.message += `: ${path}`;
+    }
+
+    throw error;
+  }
+}

--- a/bundler.ts
+++ b/bundler.ts
@@ -1,4 +1,4 @@
-import { size, timestamp } from "./_util.ts";
+import { readTextFile, size, timestamp } from "./_util.ts";
 import { colors, ImportMap, path, Sha256 } from "./deps.ts";
 import { Asset, getAsset, Graph } from "./graph.ts";
 import {
@@ -538,6 +538,6 @@ export class Bundler {
       input,
       colors.dim(cacheFilePath),
     );
-    return await Deno.readTextFile(cacheFilePath);
+    return await readTextFile(cacheFilePath);
   }
 }

--- a/cli.ts
+++ b/cli.ts
@@ -27,7 +27,12 @@ import { ServiceWorkerPlugin } from "./plugins/typescript/serviceworker.ts";
 import { SystemPlugin } from "./plugins/typescript/system.ts";
 import { TerserPlugin } from "./plugins/typescript/terser.ts";
 import { WebWorkerPlugin } from "./plugins/typescript/webworker.ts";
-import { isURL, removeRelativePrefix, timestamp } from "./_util.ts";
+import {
+  isURL,
+  readTextFile,
+  removeRelativePrefix,
+  timestamp,
+} from "./_util.ts";
 
 type Inputs = string[];
 type OutputMap = Record<string, string>;
@@ -303,11 +308,11 @@ async function runBundle(
   const cacheFilePath = path.join(cacheDirPath, cacheFileName);
 
   const { graph: initialGraph }: CacheData = fs.existsSync(cacheFilePath)
-    ? JSON.parse(await Deno.readTextFile(cacheFilePath))
+    ? JSON.parse(await readTextFile(cacheFilePath))
     : { graph: {} };
 
   const config = configFilePath && fs.existsSync(configFilePath)
-    ? JSON.parse(await Deno.readTextFile(configFilePath))
+    ? JSON.parse(await readTextFile(configFilePath))
     : {};
   const compilerOptions = config.compilerOptions
     ? ts.convertCompilerOptionsFromJson(
@@ -318,7 +323,7 @@ async function runBundle(
 
   const importMap: ImportMap =
     (importMapPath
-      ? JSON.parse(await Deno.readTextFile(importMapPath))
+      ? JSON.parse(await readTextFile(importMapPath))
       : { imports: {} });
 
   const options: Options = {

--- a/plugins/css/css.ts
+++ b/plugins/css/css.ts
@@ -14,6 +14,7 @@ import { resolve as resolveCache } from "../../cache.ts";
 import { postcssInjectImportsPlugin } from "./postcss/inject_imports.ts";
 import { postcssInjectDependenciesPlugin } from "./postcss/inject_dependencies.ts";
 import { getAsset } from "../../graph.ts";
+import { readTextFile } from "../../_util.ts";
 
 export class CssPlugin extends Plugin {
   use: postcss.AcceptedPlugin[];
@@ -51,7 +52,7 @@ export class CssPlugin extends Plugin {
     return css;
   }
   async readSource(filePath: string) {
-    return await Deno.readTextFile(filePath);
+    return await readTextFile(filePath);
   }
   async createAsset(
     item: Item,

--- a/plugins/html/html.ts
+++ b/plugins/html/html.ts
@@ -1,5 +1,6 @@
-import { fs, path, postcss, posthtml, Sha256 } from "../../deps.ts";
+import { path, postcss, posthtml, Sha256 } from "../../deps.ts";
 import { getAsset } from "../../graph.ts";
+import { readTextFile } from "../../_util.ts";
 import {
   Chunk,
   ChunkList,
@@ -39,7 +40,7 @@ export class HtmlPlugin extends Plugin {
     return input.endsWith(".html");
   }
   async readSource(filePath: string) {
-    return Deno.readTextFile(filePath);
+    return readTextFile(filePath);
   }
   async createAsset(
     item: Item,

--- a/plugins/image/svg.ts
+++ b/plugins/image/svg.ts
@@ -1,4 +1,5 @@
 import { Asset } from "../../graph.ts";
+import { readTextFile } from "../../_util.ts";
 import { FilePlugin } from "../file.ts";
 import { Context, Format, Item } from "../plugin.ts";
 
@@ -8,7 +9,7 @@ export class SvgPlugin extends FilePlugin {
     return input.endsWith(".svg");
   }
   async readSource(filePath: string, context: Context) {
-    return await Deno.readTextFile(filePath);
+    return await readTextFile(filePath);
   }
   async createAsset(
     item: Item,

--- a/plugins/json/json.ts
+++ b/plugins/json/json.ts
@@ -1,4 +1,5 @@
 import { Asset } from "../../graph.ts";
+import { readTextFile } from "../../_util.ts";
 import { FilePlugin } from "../file.ts";
 import { Context, Format, Item } from "../plugin.ts";
 
@@ -8,7 +9,7 @@ export class JsonPlugin extends FilePlugin {
     return input.endsWith(".json");
   }
   async readSource(filePath: string, context: Context) {
-    return await Deno.readTextFile(filePath);
+    return await readTextFile(filePath);
   }
   async createAsset(
     item: Item,

--- a/plugins/typescript/system.ts
+++ b/plugins/typescript/system.ts
@@ -1,5 +1,5 @@
 import { fs, path, Sha256, ts } from "../../deps.ts";
-import { addRelativePrefix, isURL } from "../../_util.ts";
+import { addRelativePrefix, isURL, readTextFile } from "../../_util.ts";
 import { Chunk, Context, DependencyType, Format } from "../plugin.ts";
 import { TypescriptPlugin } from "./typescript.ts";
 import { cache, resolve as resolveCache } from "../../cache.ts";
@@ -362,7 +362,7 @@ export class SystemPlugin extends TypescriptPlugin {
       await cache(filePath);
       filePath = resolveCache(filePath);
     }
-    return await Deno.readTextFile(filePath);
+    return await readTextFile(filePath);
   }
 
   async createBundle(

--- a/plugins/typescript/typescript.ts
+++ b/plugins/typescript/typescript.ts
@@ -12,7 +12,7 @@ import { resolve as resolveDependency } from "../../dependency.ts";
 import { typescriptExtractDependenciesTransformer } from "./transformers/extract_dependencies.ts";
 import { resolve as resolveCache } from "../../cache.ts";
 import { getAsset } from "../../graph.ts";
-import { isURL } from "../../_util.ts";
+import { isURL, readTextFile } from "../../_util.ts";
 
 function resolveDependencies(
   filePath: string,
@@ -66,7 +66,7 @@ export class TypescriptPlugin extends Plugin {
   }
   async readSource(input: string, context: Context) {
     const filePath = resolveCache(input);
-    return await Deno.readTextFile(filePath);
+    return await readTextFile(filePath);
   }
   async createAsset(
     item: Item,


### PR DESCRIPTION
Hi. I've been having some problems with missing files and I just get a stack trace that looks like this:

```
NotFound: No such file or directory (os error 2)
    at unwrapOpResult (deno:core/core.js:100:13)
    at async open (deno:runtime/js/40_files.js:46:17)
    at async Object.readTextFile (deno:runtime/js/40_read_file.js:40:18)
    at async SystemPlugin.readSource (https://deno.land/x/bundler@0.6.2/plugins/typescript/system.ts:365:12)
    at async Bundler.readSource (https://deno.land/x/bundler@0.6.2/bundler.ts:77:24)
    at async SystemPlugin.createAsset (https://deno.land/x/bundler@0.6.2/plugins/typescript/typescript.ts:78:20)
    at async Bundler.createAsset (https://deno.land/x/bundler@0.6.2/bundler.ts:127:23)
    at async Bundler.createGraph (https://deno.land/x/bundler@0.6.2/bundler.ts:207:17)
    at async Bundler.bundle (https://deno.land/x/bundler@0.6.2/bundler.ts:449:19)
    at async main (https://deno.land/x/bundler@0.6.2/cli.ts:169:39)
```

Proposing a solution here where we wrap `Deno.readTextFile` and augment NotFound error messages to include the path.

The result of this will change the above like so:

```diff
-NotFound: No such file or directory (os error 2)
+NotFound: No such file or directory (os error 2): <path>
```