### PR TITLE
Export default bug fixes

### DIFF
--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1778,7 +1778,7 @@ tests({
               `/* testdata/typescript/export_default_class/b.ts */
               const mod = (async () => {
                 class b { static value = "b"; }
-                return { default: _default };
+                return { default: b };
               })();
               export default (async () => {
                 const { b } = await mod;

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -2057,6 +2057,7 @@ tests({
 
         {
           name: "export default type",
+          ignore: true,
           async fn() {
             const inputs = [
               "testdata/typescript/export_default_type/a.ts",
@@ -2123,12 +2124,27 @@ tests({
             const bundles = await bundler.createBundles(chunks, graph);
             assertEquals(Object.keys(bundles).length, 1);
             const bundle = bundles[output] as string;
+
+            /* Current incorrect output:
+
+              const mod = (async () => {
+                const _default = b; // <-- wrong: b doesn't exist
+                                    // also, _default is unused?
+                return { default: b };
+              })();
+              export default (async () => {
+                const b = (await mod).default;
+                return {};
+              })();
+
+            */
+
             assertEqualsIgnoreWhitespace(
               bundle,
               `/* testdata/typescript/export_default_type/b.ts */
               const mod = (async () => {
-                const _default = b;
-                return { default: b };
+                const _default = undefined;
+                return { default: _default };
               })();
               export default (async () => {
                 const b = (await mod).default;

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file
 import { defaultPlugins } from "./_bundler_utils.ts";
 
 import {
@@ -1705,6 +1706,174 @@ tests({
         },
 
         {
+          name: "export default class",
+          async fn() {
+            throw new Error("TODO");
+            const inputs = [
+              "testdata/typescript/export_default/a.ts",
+            ];
+            const output =
+              "dist/deps/6ff2f43df916e1866ff3f687dde57cc6a5950126905560de2ef2db6fd648cceb.js";
+
+            const graph = await bundler.createGraph(inputs);
+            assertEquals(graph, {
+              "testdata/typescript/export_default/a.ts": [
+                {
+                  dependencies: {
+                    "testdata/typescript/export_default/b.ts": {
+                      Import: {
+                        specifiers: {
+                          b: "default",
+                        },
+                      },
+                    },
+                  },
+                  export: {
+                    specifiers: {
+                      b: "b",
+                    },
+                  },
+                  input: "testdata/typescript/export_default/a.ts",
+                  output,
+                  type: "Import",
+                },
+              ],
+              "testdata/typescript/export_default/b.ts": [
+                {
+                  dependencies: {},
+                  export: {
+                    default: true,
+                  },
+                  input: "testdata/typescript/export_default/b.ts",
+                  output:
+                    "dist/deps/fce9005f06acca1dcf725f2fe883a580169f1eb2d7adb83162ae249f53f7add5.js",
+                  type: "Import",
+                },
+              ],
+            });
+            const chunks = await bundler.createChunks(inputs, graph);
+            assertEquals(chunks, [
+              {
+                item: {
+                  history: [
+                    "testdata/typescript/export_default/a.ts",
+                  ],
+                  type: "Import",
+                },
+                dependencyItems: [
+                  {
+                    history: [
+                      "testdata/typescript/export_default/b.ts",
+                      "testdata/typescript/export_default/a.ts",
+                    ],
+                    type: "Import",
+                  },
+                ],
+              },
+            ]);
+            const bundles = await bundler.createBundles(chunks, graph);
+            assertEquals(Object.keys(bundles).length, 1);
+            const bundle = bundles[output] as string;
+            assertEqualsIgnoreWhitespace(
+              bundle,
+              `/* testdata/typescript/export_default/b.ts */
+              const mod = (async () => {
+                const _default = "b";
+                return { default: _default };
+              })();
+              export default (async () => {
+                const { default: b } = await mod;
+                return { b };
+              })();`,
+            );
+          },
+        },
+
+        {
+          name: "export default function",
+          async fn() {
+            throw new Error("TODO");
+            const inputs = [
+              "testdata/typescript/export_default/a.ts",
+            ];
+            const output =
+              "dist/deps/6ff2f43df916e1866ff3f687dde57cc6a5950126905560de2ef2db6fd648cceb.js";
+
+            const graph = await bundler.createGraph(inputs);
+            assertEquals(graph, {
+              "testdata/typescript/export_default/a.ts": [
+                {
+                  dependencies: {
+                    "testdata/typescript/export_default/b.ts": {
+                      Import: {
+                        specifiers: {
+                          b: "default",
+                        },
+                      },
+                    },
+                  },
+                  export: {
+                    specifiers: {
+                      b: "b",
+                    },
+                  },
+                  input: "testdata/typescript/export_default/a.ts",
+                  output,
+                  type: "Import",
+                },
+              ],
+              "testdata/typescript/export_default/b.ts": [
+                {
+                  dependencies: {},
+                  export: {
+                    default: true,
+                  },
+                  input: "testdata/typescript/export_default/b.ts",
+                  output:
+                    "dist/deps/fce9005f06acca1dcf725f2fe883a580169f1eb2d7adb83162ae249f53f7add5.js",
+                  type: "Import",
+                },
+              ],
+            });
+            const chunks = await bundler.createChunks(inputs, graph);
+            assertEquals(chunks, [
+              {
+                item: {
+                  history: [
+                    "testdata/typescript/export_default/a.ts",
+                  ],
+                  type: "Import",
+                },
+                dependencyItems: [
+                  {
+                    history: [
+                      "testdata/typescript/export_default/b.ts",
+                      "testdata/typescript/export_default/a.ts",
+                    ],
+                    type: "Import",
+                  },
+                ],
+              },
+            ]);
+            const bundles = await bundler.createBundles(chunks, graph);
+            assertEquals(Object.keys(bundles).length, 1);
+            const bundle = bundles[output] as string;
+            assertEqualsIgnoreWhitespace(
+              bundle,
+              `/* testdata/typescript/export_default/b.ts */
+              const mod = (async () => {
+                const _default = "b";
+                return { default: _default };
+              })();
+              export default (async () => {
+                const { default: b } = await mod;
+                return { b };
+              })();`,
+            );
+          },
+        },
+
+        {
           name: "export default specifier",
           async fn() {
             const inputs = [
@@ -1778,6 +1947,90 @@ tests({
                 const b = (await mod).default;
                 console.log(b);
                 return {};
+              })();`,
+            );
+          },
+        },
+
+        {
+          name: "export default type",
+          async fn() {
+            throw new Error("TODO");
+            const inputs = [
+              "testdata/typescript/export_default/a.ts",
+            ];
+            const output =
+              "dist/deps/6ff2f43df916e1866ff3f687dde57cc6a5950126905560de2ef2db6fd648cceb.js";
+
+            const graph = await bundler.createGraph(inputs);
+            assertEquals(graph, {
+              "testdata/typescript/export_default/a.ts": [
+                {
+                  dependencies: {
+                    "testdata/typescript/export_default/b.ts": {
+                      Import: {
+                        specifiers: {
+                          b: "default",
+                        },
+                      },
+                    },
+                  },
+                  export: {
+                    specifiers: {
+                      b: "b",
+                    },
+                  },
+                  input: "testdata/typescript/export_default/a.ts",
+                  output,
+                  type: "Import",
+                },
+              ],
+              "testdata/typescript/export_default/b.ts": [
+                {
+                  dependencies: {},
+                  export: {
+                    default: true,
+                  },
+                  input: "testdata/typescript/export_default/b.ts",
+                  output:
+                    "dist/deps/fce9005f06acca1dcf725f2fe883a580169f1eb2d7adb83162ae249f53f7add5.js",
+                  type: "Import",
+                },
+              ],
+            });
+            const chunks = await bundler.createChunks(inputs, graph);
+            assertEquals(chunks, [
+              {
+                item: {
+                  history: [
+                    "testdata/typescript/export_default/a.ts",
+                  ],
+                  type: "Import",
+                },
+                dependencyItems: [
+                  {
+                    history: [
+                      "testdata/typescript/export_default/b.ts",
+                      "testdata/typescript/export_default/a.ts",
+                    ],
+                    type: "Import",
+                  },
+                ],
+              },
+            ]);
+            const bundles = await bundler.createBundles(chunks, graph);
+            assertEquals(Object.keys(bundles).length, 1);
+            const bundle = bundles[output] as string;
+            assertEqualsIgnoreWhitespace(
+              bundle,
+              `/* testdata/typescript/export_default/b.ts */
+              const mod = (async () => {
+                const _default = "b";
+                return { default: _default };
+              })();
+              export default (async () => {
+                const { default: b } = await mod;
+                return { b };
               })();`,
             );
           },

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1896,19 +1896,18 @@ tests({
         {
           name: "export default function",
           async fn() {
-            throw new Error("TODO");
             const inputs = [
-              "testdata/typescript/export_default/a.ts",
+              "testdata/typescript/export_default_function/a.ts",
             ];
             const output =
-              "dist/deps/6ff2f43df916e1866ff3f687dde57cc6a5950126905560de2ef2db6fd648cceb.js";
+              "dist/deps/90af3b98694e54446931d597951df0f3dc4791e140fb398be6f171047b2c6caa.js";
 
             const graph = await bundler.createGraph(inputs);
             assertEquals(graph, {
-              "testdata/typescript/export_default/a.ts": [
+              "testdata/typescript/export_default_function/a.ts": [
                 {
                   dependencies: {
-                    "testdata/typescript/export_default/b.ts": {
+                    "testdata/typescript/export_default_function/b.ts": {
                       Import: {
                         specifiers: {
                           b: "default",
@@ -1921,20 +1920,20 @@ tests({
                       b: "b",
                     },
                   },
-                  input: "testdata/typescript/export_default/a.ts",
+                  input: "testdata/typescript/export_default_function/a.ts",
                   output,
                   type: "Import",
                 },
               ],
-              "testdata/typescript/export_default/b.ts": [
+              "testdata/typescript/export_default_function/b.ts": [
                 {
                   dependencies: {},
                   export: {
-                    default: true,
+                    default: "b",
                   },
-                  input: "testdata/typescript/export_default/b.ts",
+                  input: "testdata/typescript/export_default_function/b.ts",
                   output:
-                    "dist/deps/fce9005f06acca1dcf725f2fe883a580169f1eb2d7adb83162ae249f53f7add5.js",
+                    "dist/deps/be37210a25479a644f6c18d78b8a37b6372aedd9c4f59c8c3d70e32688ae85e8.js",
                   type: "Import",
                 },
               ],
@@ -1944,15 +1943,15 @@ tests({
               {
                 item: {
                   history: [
-                    "testdata/typescript/export_default/a.ts",
+                    "testdata/typescript/export_default_function/a.ts",
                   ],
                   type: "Import",
                 },
                 dependencyItems: [
                   {
                     history: [
-                      "testdata/typescript/export_default/b.ts",
-                      "testdata/typescript/export_default/a.ts",
+                      "testdata/typescript/export_default_function/b.ts",
+                      "testdata/typescript/export_default_function/a.ts",
                     ],
                     type: "Import",
                   },
@@ -1964,10 +1963,10 @@ tests({
             const bundle = bundles[output] as string;
             assertEqualsIgnoreWhitespace(
               bundle,
-              `/* testdata/typescript/export_default/b.ts */
+              `/* testdata/typescript/export_default_function/b.ts */
               const mod = (async () => {
-                const _default = "b";
-                return { default: _default };
+                function b() { return "b"; }
+                return { default: b };
               })();
               export default (async () => {
                 const { default: b } = await mod;

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -2058,45 +2058,44 @@ tests({
         {
           name: "export default type",
           async fn() {
-            throw new Error("TODO");
             const inputs = [
-              "testdata/typescript/export_default/a.ts",
+              "testdata/typescript/export_default_type/a.ts",
             ];
             const output =
-              "dist/deps/6ff2f43df916e1866ff3f687dde57cc6a5950126905560de2ef2db6fd648cceb.js";
+              "dist/deps/1d17533ba9bc2895477b9ec6d18f796cf22e977c079b59ff72cdd18c835c8c21.js";
 
             const graph = await bundler.createGraph(inputs);
             assertEquals(graph, {
-              "testdata/typescript/export_default/a.ts": [
+              "testdata/typescript/export_default_type/a.ts": [
                 {
                   dependencies: {
-                    "testdata/typescript/export_default/b.ts": {
+                    "testdata/typescript/export_default_type/b.ts": {
                       Import: {
-                        specifiers: {
-                          b: "default",
-                        },
+                        defaults: [
+                          "b",
+                        ],
                       },
                     },
                   },
                   export: {
-                    specifiers: {
+                    types: {
                       b: "b",
                     },
                   },
-                  input: "testdata/typescript/export_default/a.ts",
+                  input: "testdata/typescript/export_default_type/a.ts",
                   output,
                   type: "Import",
                 },
               ],
-              "testdata/typescript/export_default/b.ts": [
+              "testdata/typescript/export_default_type/b.ts": [
                 {
                   dependencies: {},
                   export: {
-                    default: true,
+                    default: "b",
                   },
-                  input: "testdata/typescript/export_default/b.ts",
+                  input: "testdata/typescript/export_default_type/b.ts",
                   output:
-                    "dist/deps/fce9005f06acca1dcf725f2fe883a580169f1eb2d7adb83162ae249f53f7add5.js",
+                    "dist/deps/c1ecb8968b541b3a13d61cdac16d61c9255819f7b87300145a3fd0ea9e0d7bf7.js",
                   type: "Import",
                 },
               ],
@@ -2106,15 +2105,15 @@ tests({
               {
                 item: {
                   history: [
-                    "testdata/typescript/export_default/a.ts",
+                    "testdata/typescript/export_default_type/a.ts",
                   ],
                   type: "Import",
                 },
                 dependencyItems: [
                   {
                     history: [
-                      "testdata/typescript/export_default/b.ts",
-                      "testdata/typescript/export_default/a.ts",
+                      "testdata/typescript/export_default_type/b.ts",
+                      "testdata/typescript/export_default_type/a.ts",
                     ],
                     type: "Import",
                   },
@@ -2126,14 +2125,14 @@ tests({
             const bundle = bundles[output] as string;
             assertEqualsIgnoreWhitespace(
               bundle,
-              `/* testdata/typescript/export_default/b.ts */
+              `/* testdata/typescript/export_default_type/b.ts */
               const mod = (async () => {
-                const _default = "b";
-                return { default: _default };
+                const _default = b;
+                return { default: b };
               })();
               export default (async () => {
-                const { default: b } = await mod;
-                return { b };
+                const b = (await mod).default;
+                return {};
               })();`,
             );
           },

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1708,19 +1708,18 @@ tests({
         {
           name: "export default class",
           async fn() {
-            throw new Error("TODO");
             const inputs = [
-              "testdata/typescript/export_default/a.ts",
+              "testdata/typescript/export_default_class/a.ts",
             ];
             const output =
-              "dist/deps/6ff2f43df916e1866ff3f687dde57cc6a5950126905560de2ef2db6fd648cceb.js";
+              "dist/deps/8fb15a7ad25e3c2486ed30cf0a6ed27fa97c8a176d10ce11704dbb6482ed0895.js";
 
             const graph = await bundler.createGraph(inputs);
             assertEquals(graph, {
-              "testdata/typescript/export_default/a.ts": [
+              "testdata/typescript/export_default_class/a.ts": [
                 {
                   dependencies: {
-                    "testdata/typescript/export_default/b.ts": {
+                    "testdata/typescript/export_default_class/b.ts": {
                       Import: {
                         specifiers: {
                           b: "default",
@@ -1733,20 +1732,20 @@ tests({
                       b: "b",
                     },
                   },
-                  input: "testdata/typescript/export_default/a.ts",
+                  input: "testdata/typescript/export_default_class/a.ts",
                   output,
                   type: "Import",
                 },
               ],
-              "testdata/typescript/export_default/b.ts": [
+              "testdata/typescript/export_default_class/b.ts": [
                 {
                   dependencies: {},
                   export: {
-                    default: true,
+                    default: "b",
                   },
-                  input: "testdata/typescript/export_default/b.ts",
+                  input: "testdata/typescript/export_default_class/b.ts",
                   output:
-                    "dist/deps/fce9005f06acca1dcf725f2fe883a580169f1eb2d7adb83162ae249f53f7add5.js",
+                    "dist/deps/9a7abf52380486f522eaff375bb2bc553e8111f68974e69d99d335a16f27eff4.js",
                   type: "Import",
                 },
               ],
@@ -1756,15 +1755,15 @@ tests({
               {
                 item: {
                   history: [
-                    "testdata/typescript/export_default/a.ts",
+                    "testdata/typescript/export_default_class/a.ts",
                   ],
                   type: "Import",
                 },
                 dependencyItems: [
                   {
                     history: [
-                      "testdata/typescript/export_default/b.ts",
-                      "testdata/typescript/export_default/a.ts",
+                      "testdata/typescript/export_default_class/b.ts",
+                      "testdata/typescript/export_default_class/a.ts",
                     ],
                     type: "Import",
                   },
@@ -1776,13 +1775,13 @@ tests({
             const bundle = bundles[output] as string;
             assertEqualsIgnoreWhitespace(
               bundle,
-              `/* testdata/typescript/export_default/b.ts */
+              `/* testdata/typescript/export_default_class/b.ts */
               const mod = (async () => {
-                const _default = "b";
+                class b { static value = "b"; }
                 return { default: _default };
               })();
               export default (async () => {
-                const { default: b } = await mod;
+                const { b } = await mod;
                 return { b };
               })();`,
             );

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1557,7 +1557,7 @@ tests({
                 return { c };
               })();
               const mod = (async () => {
-                const { c2 } = await mod1;
+                const { c: c2 } = await mod1;
                 return { c2 };
               })();
               export default (async () => {

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1886,7 +1886,7 @@ tests({
                 return { default: b };
               })();
               export default (async () => {
-                const b = (await mod).default;
+                const { default: b } = await mod;
                 return { b };
               })();`,
             );

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1,4 +1,3 @@
-// deno-lint-ignore-file
 import { defaultPlugins } from "./_bundler_utils.ts";
 
 import {

--- a/plugins/typescript/transformers/imports_exports.ts
+++ b/plugins/typescript/transformers/imports_exports.ts
@@ -190,7 +190,7 @@ export function typescriptTransformImportsExportsTransformer(
 
                   if (identifierMap.has(text)) {
                     name = identifierMap.get(text)!;
-                    propertyName = text;
+                    propertyName ??= text;
                   }
 
                   const usedImportSpecifiers = usedImports[identifier] =

--- a/plugins/typescript/typescript_top_level_await_module.ts
+++ b/plugins/typescript/typescript_top_level_await_module.ts
@@ -487,7 +487,10 @@ function createReturnStatement(
   const propertySpecifierEntries: [string, string][] = [];
 
   if (_export.default) {
-    propertySpecifierEntries.push([defaultKeyword, defaultIdentifier]);
+    const identifier = typeof _export.default === "string"
+      ? _export.default
+      : defaultIdentifier;
+    propertySpecifierEntries.push([defaultKeyword, identifier]);
   }
   if (specifiers) {
     propertySpecifierEntries.push(...Object.entries(specifiers));

--- a/testdata/typescript/export_as_specifier/a.ts
+++ b/testdata/typescript/export_as_specifier/a.ts
@@ -1,0 +1,3 @@
+import { c2 } from "./b.ts";
+
+console.log(c2);

--- a/testdata/typescript/export_as_specifier/b.ts
+++ b/testdata/typescript/export_as_specifier/b.ts
@@ -1,0 +1,1 @@
+export { c as c2 } from "./c.ts";

--- a/testdata/typescript/export_as_specifier/c.ts
+++ b/testdata/typescript/export_as_specifier/c.ts
@@ -1,0 +1,1 @@
+export const c = "c";

--- a/testdata/typescript/export_default_class/a.ts
+++ b/testdata/typescript/export_default_class/a.ts
@@ -1,0 +1,1 @@
+export { default as b } from "./b.ts";

--- a/testdata/typescript/export_default_class/b.ts
+++ b/testdata/typescript/export_default_class/b.ts
@@ -1,0 +1,3 @@
+export default class b {
+  static value = "b";
+}

--- a/testdata/typescript/export_default_function/a.ts
+++ b/testdata/typescript/export_default_function/a.ts
@@ -1,0 +1,1 @@
+export { default as b } from "./b.ts";

--- a/testdata/typescript/export_default_function/b.ts
+++ b/testdata/typescript/export_default_function/b.ts
@@ -1,0 +1,3 @@
+export default function b() {
+  return "b";
+}

--- a/testdata/typescript/export_default_type/a.ts
+++ b/testdata/typescript/export_default_type/a.ts
@@ -1,0 +1,2 @@
+import b from "./b.ts";
+export type { b };

--- a/testdata/typescript/export_default_type/b.ts
+++ b/testdata/typescript/export_default_type/b.ts
@@ -1,0 +1,2 @@
+type b = "b";
+export default b;


### PR DESCRIPTION
## Summary

- Fixes two export bugs
- Documents a third bug with a test (sadly, I couldn't find a simple fix)

## Bug 1: When using `export default function` or `export default class`, the generated export uses the name `_default` but this name doesn't exist because TypeScript exposes the name of the function/class.

For example this code:
```ts
export default function foo() {}
```

Will be transpiled as:
```js
function foo() {}
```

Before the PR, the generated export expected that function to be available via the name `_default`, but it is not.

The fix is to use the default export name from the AST if it is provided (if it is just `true`, then `_default` is correct):

```diff
   const propertySpecifierEntries: [string, string][] = [];

   if (_export.default) {
-    propertySpecifierEntries.push([defaultKeyword, defaultIdentifier]);
+    const identifier = typeof _export.default === "string"
+      ? _export.default
+      : defaultIdentifier;
+    propertySpecifierEntries.push([defaultKeyword, identifier]);
   }
   if (specifiers) {
     propertySpecifierEntries.push(...Object.entries(specifiers));
```

## Bug 2: When exporting a name from another module as another name (using `as`), and the import name is in the `identifierMap`, the `as` name is dropped - the code is emitted as though the `as` rename was not there.

For example this code:
```ts
export { c as c2 } from "./c.ts";
```

Is bundled, prior to this PR, as:
```js
const modB = (async () => {
  const { c2 } = await modC;
  return { c2 };
});
```

with this PR, it is now bundled as:
```js
const modB = (async () => {
  const { c: c2 } = await modC;
  return { c2 };
});
```

Notes:
- Having `c2` in `identifierMap` is required to reproduce. See `testdata/typescript/export_as_specifier` for a full repro case.
- `c2` will still be correctly mapped by `identifierMap` if needed, it's the `c` that needs to be preserved, which happily does not need to be mapped since it does not create the name in the scope (thus not creating the shadowing issue that I assume `identifierMap` is fixing).

This one is fixed by avoiding overwriting `propertyName` if it exists:

```diff
-  propertyName = text;
+  propertyName ??= text;
```

This line is intended to generate some `as` code where none was needed before `identifierMap` was applied. However, when `propertyName` already exists, it correctly refers to the name from the external module and does not need to be changed.

## Bug 3: When `X` is a type only, `export default X` bundles code that references `X`, but `X` does not exist

For example this code:
```ts
type X = string;
export default X;
```

Is bundled as:
```js
const modX = (async () => {
  const _default = X;
  return { default: X };
});
```

I wasn't able to fix this one :(, but I added an ignored test to document it.