### PR TITLE
Add new test case that needs to be ignored - circular dependency subtle

### DIFF
--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -31,6 +31,22 @@ tests({
       },
     },
     {
+      name: "circular dependency subtle",
+      ignore: true,
+      async fn() {
+        const inputs = [
+          "testdata/circular_subtle/a.ts",
+        ];
+        await assertThrowsAsync(
+          async () => {
+            await bundler.createGraph(inputs);
+          },
+          Error,
+          "Circular Dependency",
+        );
+      },
+    },
+    {
       name: "typescript",
       tests: () => [
         {

--- a/testdata/circular_subtle/a.ts
+++ b/testdata/circular_subtle/a.ts
@@ -1,0 +1,2 @@
+import "./b.ts";
+import "./c.ts";

--- a/testdata/circular_subtle/b.ts
+++ b/testdata/circular_subtle/b.ts
@@ -1,0 +1,1 @@
+import "./c.ts";

--- a/testdata/circular_subtle/c.ts
+++ b/testdata/circular_subtle/c.ts
@@ -1,0 +1,1 @@
+import "./b.ts";


### PR DESCRIPTION
Not detected as circular:
entry depends on two modules
those two modules depends on each other

This produces a bundle that doesn't execute correctly e.g.:
```
error: Uncaught (in promise) ReferenceError: Cannot access 'mod' before initialization
    const { B } = await mod;
```