### PR TITLE
Ignore type-only dependencies

### DIFF
--- a/bundler.ts
+++ b/bundler.ts
@@ -46,6 +46,7 @@ export interface CreateGraphOptions extends Options {
   graph?: Graph;
   outDirPath?: string;
   outputMap?: OutputMap;
+  includeTypeOnly?: boolean;
 }
 
 export interface CreateChunkOptions extends Options {
@@ -200,6 +201,7 @@ export class Bundler {
       }),
 
       ...options,
+      includeTypeOnly: options.includeTypeOnly ?? true,
 
       bundler: this,
     };
@@ -620,7 +622,7 @@ export class Bundler {
 
     const graph = await this.createGraph(
       inputs,
-      { ...options },
+      { ...options, includeTypeOnly: false },
     );
     const chunks = await this.createChunks(
       inputs,

--- a/bundler_test.ts
+++ b/bundler_test.ts
@@ -1317,29 +1317,9 @@ tests({
             assertEquals(graph, {
               "testdata/typescript/import_type/a.ts": [{
                 export: {},
-                dependencies: {
-                  "testdata/typescript/import_type/b.ts": {
-                    Import: {
-                      types: {
-                        B: "B",
-                      },
-                    },
-                  },
-                },
+                dependencies: {},
                 input: "testdata/typescript/import_type/a.ts",
                 output,
-                type: "Import",
-              }],
-              "testdata/typescript/import_type/b.ts": [{
-                export: {
-                  types: {
-                    B: "B",
-                  },
-                },
-                dependencies: {},
-                input: "testdata/typescript/import_type/b.ts",
-                output:
-                  "dist/deps/e62c2b1ec2459e538fee02be73f94fdb515c86e30513f0128d0462e34d4bfb3b.js",
                 type: "Import",
               }],
             });
@@ -1350,15 +1330,7 @@ tests({
                   history: ["testdata/typescript/import_type/a.ts"],
                   type: "Import",
                 },
-                dependencyItems: [
-                  {
-                    history: [
-                      "testdata/typescript/import_type/b.ts",
-                      "testdata/typescript/import_type/a.ts",
-                    ],
-                    type: "Import",
-                  },
-                ],
+                dependencyItems: [],
               },
             ]);
             const bundles = await bundler.createBundles(chunks, graph);
@@ -1366,12 +1338,8 @@ tests({
             const bundle = bundles[output] as string;
             assertEqualsIgnoreWhitespace(
               bundle,
-              `/* testdata/typescript/import_type/b.ts */
-              const mod = (async () => {
-                return {};
-              })();
+              `/* testdata/typescript/import_type/a.ts */
               export default (async () => {
-                const { B } = await mod;
                 const a = "a";
                 console.log(a);
                 return {};

--- a/plugins/plugin.ts
+++ b/plugins/plugin.ts
@@ -105,6 +105,7 @@ export type Context = {
   optimize: boolean;
   quiet: boolean;
   outputMap: OutputMap;
+  includeTypeOnly?: boolean;
 
   graph: Graph;
   chunks: Chunks;

--- a/plugins/typescript/dependencies/extract_dependencies.ts
+++ b/plugins/typescript/dependencies/extract_dependencies.ts
@@ -321,16 +321,3 @@ export function extractDependenciesFromSourceFile(
   );
   return moduleData;
 }
-
-export function extractDependencies(
-  fileName: string,
-  sourceText: string,
-  compilerOptions?: ts.CompilerOptions,
-) {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    sourceText,
-    ts.ScriptTarget.Latest,
-  );
-  return extractDependenciesFromSourceFile(sourceFile, compilerOptions);
-}

--- a/plugins/typescript/transformers/imports_exports.ts
+++ b/plugins/typescript/transformers/imports_exports.ts
@@ -41,7 +41,7 @@ export function typescriptTransformImportsExportsTransformer(
       return (node: ts.Node) => {
         if (ts.isImportDeclaration(node)) {
           const importClause = node.importClause;
-          // if (importClause?.isTypeOnly) return undefined;
+          if (importClause?.isTypeOnly) return undefined;
           if (ts.isStringLiteral(node.moduleSpecifier)) {
             const resolvedSpecifier = resolve(node.moduleSpecifier.text);
 
@@ -146,7 +146,7 @@ export function typescriptTransformImportsExportsTransformer(
           }
           return node;
         } else if (ts.isExportDeclaration(node)) {
-          // if (node.isTypeOnly) return undefined;
+          if (node.isTypeOnly) return undefined;
           if (
             node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)
           ) {

--- a/plugins/typescript/typescript.ts
+++ b/plugins/typescript/typescript.ts
@@ -53,11 +53,21 @@ export class TypescriptPlugin extends Plugin {
     const { history, type } = item;
     const input = history[0];
 
-    const { bundler, outputMap, depsDirPath, importMap } = context;
+    const {
+      bundler,
+      outputMap,
+      depsDirPath,
+      importMap,
+      includeTypeOnly = false,
+    } = context;
 
     const sourceFile = await bundler.readSource(item, context) as ts.SourceFile;
 
-    const dependencies = extractDependenciesFromSourceFile(sourceFile);
+    const dependencies = extractDependenciesFromSourceFile(
+      sourceFile,
+      {},
+      { includeTypeOnly },
+    );
 
     const resolvedModuleData = resolveDependencies(
       input,


### PR DESCRIPTION
Since we're transpiling to js, type-only dependencies should have no effect, so we should be ignoring them.

Caveat: Do type names have an effect on name mangling?

This has the following benefits:
- Avoid emitting dead code when a file is imported only for its types (and has other non-type code in it)
- Tolerate circular dependencies that are only circular by type-only dependencies
- Avoid initialization ordering bugs created by undetected circular dependencies when the circular dependency is type-only ([more info](https://github.com/timreichen/Bundler/pull/50))