### PR TITLE
Compiler options fixes

### DIFF
--- a/server_cli.ts
+++ b/server_cli.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env -S deno run --unstable --allow-net --allow-read --allow-write
 
 import { parse } from "https://deno.land/std@0.100.0/flags/mod.ts";
+import { Bundler } from "./bundler.ts";
 import { Server } from "./server.ts";
+import { defaultPlugins } from "./_bundler_utils.ts";
 import { createOptions } from "./_util.ts";
 
 const args = parse(Deno.args);
@@ -10,6 +12,13 @@ const { inputs, ...options } = await createOptions({
   ...args,
   "out-dir": "",
 });
+
+const bundler = new Bundler(
+  defaultPlugins({
+    typescriptCompilerOptions: options.compilerOptions,
+  }),
+);
+
 const input = inputs[0];
 const index = options.outputMap[input] || "index.html";
 
@@ -18,6 +27,6 @@ options.outputMap = {
   [input]: index,
 };
 
-const server = new Server({ index });
+const server = new Server({ index, bundler });
 await server.bundle(inputs, options);
 await server.listen({ port });

--- a/spa_server_cli.ts
+++ b/spa_server_cli.ts
@@ -1,13 +1,21 @@
 #!/usr/bin/env -S deno run --unstable --allow-net --allow-read --allow-write
 
 import { parse } from "https://deno.land/std@0.100.0/flags/mod.ts";
+import { Bundler } from "./bundler.ts";
 import { Server } from "./server.ts";
+import { defaultPlugins } from "./_bundler_utils.ts";
 import { createOptions } from "./_util.ts";
 
 class SpaServer extends Server {
   index: string;
-  constructor({ index = "index.html" }: { index?: string } = {}) {
-    super();
+  constructor({
+    index = "index.html",
+    bundler = new Bundler(defaultPlugins()),
+  }: {
+    index?: string;
+    bundler?: Bundler;
+  } = {}) {
+    super({ bundler });
     this.index = index;
   }
   async handle(request: Request) {
@@ -25,12 +33,18 @@ const args = parse(Deno.args);
 const { port = 8000 } = args;
 const { inputs, ...options } = await createOptions(args);
 
+const bundler = new Bundler(
+  defaultPlugins({
+    typescriptCompilerOptions: options.compilerOptions,
+  }),
+);
+
 const input = inputs[0];
 const index = "index.html";
 options.outputMap = {
   ...options.outputMap,
   [input]: index,
 };
-const server = new SpaServer({ index });
+const server = new SpaServer({ index, bundler });
 await server.bundle(inputs, options);
 await server.listen({ port });


### PR DESCRIPTION
Fix passing in `compilerOptions` based on `--config` CLI option.

My use case for this is being able to use preact by passing `--config=/path/to/tsconfig.json` with:

```json
{
  "compilerOptions": {
    "jsx": "react",
    "jsxFactory": "preact.h",
    "jsxFragmentFactory": "preact.Fragment"
  }
}
```

Two issues were preventing this from happening:
1. In `server_cli.ts`, `spa_server_cli.ts`, options weren't passed through to `defaultPlugins`
2. `ts.convertCompilerOptionsFromJson` was being called with `{ compilerOptions }` when it should have been called without the wrapper, ie just `compilerOptions`.