### PR TITLE
file path fix

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -75,9 +75,9 @@ function parseBundleArgs(args: flags.Args) {
   const outputMap = Object.fromEntries(_.map((entry) => {
     let { input, output } = regex.exec(entry as string)?.groups || {};
     if (!isURL(input)) {
-      input = new URL(path.resolve(Deno.cwd(), input), "file://").href;
+      input = path.toFileUrl(path.resolve(Deno.cwd(), input)).href;
     }
-    if (output) output = new URL(path.join(root, output), "file://").href;
+    if (output) output = path.toFileUrl(path.join(root, output)).href;
     return [input, output];
   }));
 


### PR DESCRIPTION
https://github.com/timreichen/Bundler/pull/61
fixes a bug that causes paths to break on windows os.